### PR TITLE
Return Error::ResponseError for API errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Bugfixes
+
+- Return `Error::ResponseError` instead of `Error::Transport` for API errors ([#21](https://github.com/Nitrokey/nethsm-sdk-rs/issues/21))
+
+[All Changes](https://github.com/Nitrokey/nethsm-sdk-rs/compare/v1.0.1...HEAD)
+
 ## [v1.0.1](https://github.com/Nitrokey/nethsm-sdk-rs/releases/tag/v1.0.1) (2024-05-06)
 
 ### Bugfixes

--- a/generator/src/main/resources/crust/reqwest/api.mustache
+++ b/generator/src/main/resources/crust/reqwest/api.mustache
@@ -290,27 +290,27 @@ pub fn {{{operationId}}}(configuration: &configuration::Configuration, {{#allPar
     let body_json = body.is_json();
     local_var_req_builder = local_var_req_builder.set("content-type", body.content_type());
     {{/bodyParams}}{{/hasBodyParam}} 
-    let local_var_resp = if body_json {
-        local_var_req_builder.send_json(body)?
+    let local_var_result = if body_json {
+        local_var_req_builder.send_json(body)
     } else {
-        local_var_req_builder.send_string(body.get_string().as_str())?
+        local_var_req_builder.send_string(body.get_string().as_str())
     };
     {{/vendorExtensions.x-consumeMultipleMediaTypes}}
     {{^vendorExtensions.x-consumeMultipleMediaTypes}}
     {{#consumes}}
     local_var_req_builder = local_var_req_builder.set("content-type", "{{{mediaType}}}");
     {{#mediaIsJson}}
-    let local_var_resp = local_var_req_builder.send_json(
+    let local_var_result = local_var_req_builder.send_json(
     {{/mediaIsJson}}
     {{^mediaIsJson}}
     {{#hasBodyParam}}
     {{#bodyParams}}
     {{#isFile}}
     let {{{paramName}}} = std::io::Cursor::new({{{paramName}}});
-    let local_var_resp = local_var_req_builder.send(
+    let local_var_result = local_var_req_builder.send(
     {{/isFile}}
     {{^isFile}}
-    let local_var_resp = local_var_req_builder.send_string(
+    let local_var_result = local_var_req_builder.send_string(
     {{/isFile}}
     {{/bodyParams}}
     {{/hasBodyParam}}
@@ -323,11 +323,16 @@ pub fn {{{operationId}}}(configuration: &configuration::Configuration, {{#allPar
     {{/hasBodyParam}}
     {{#consumes}}
     {{/consumes}}
-    {{#hasBodyParam}})?;{{/hasBodyParam}}
+    {{#hasBodyParam}});{{/hasBodyParam}}
     {{/vendorExtensions.x-consumeMultipleMediaTypes}}
     {{^hasBodyParam}}
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
     {{/hasBodyParam}}
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
 
     let local_var_headers = super::get_header_map(&local_var_resp);
@@ -338,7 +343,7 @@ pub fn {{{operationId}}}(configuration: &configuration::Configuration, {{#allPar
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         {{#vendorExtensions.x-produceMultipleMediaTypes}}
         {{#returnType}}
         let local_var_entity : {{{returnType}}} = if is_json { serde_json::from_slice(&local_var_content).map_err(Error::from)? } else {  String::from_utf8(local_var_content)? };

--- a/src/apis/default_api.rs
+++ b/src/apis/default_api.rs
@@ -769,7 +769,12 @@ pub fn config_backup_passphrase_put(
     };
 
     local_var_req_builder = local_var_req_builder.set("content-type", "application/json");
-    let local_var_resp = local_var_req_builder.send_json(backup_passphrase_config)?;
+    let local_var_result = local_var_req_builder.send_json(backup_passphrase_config);
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -781,7 +786,7 @@ pub fn config_backup_passphrase_put(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_result = ResponseContent {
             status: local_var_status,
             content: local_var_content_clone,
@@ -825,7 +830,12 @@ pub fn config_logging_get(
     let accept_str = "application/json";
     local_var_req_builder = local_var_req_builder.set("accept", accept_str);
 
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -837,7 +847,7 @@ pub fn config_logging_get(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_entity: crate::models::LoggingConfig =
             serde_json::from_slice(&local_var_content).map_err(Error::from)?;
         let local_var_result = ResponseContent {
@@ -882,7 +892,12 @@ pub fn config_logging_put(
     };
 
     local_var_req_builder = local_var_req_builder.set("content-type", "application/json");
-    let local_var_resp = local_var_req_builder.send_json(logging_config)?;
+    let local_var_result = local_var_req_builder.send_json(logging_config);
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -894,7 +909,7 @@ pub fn config_logging_put(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_result = ResponseContent {
             status: local_var_status,
             content: local_var_content_clone,
@@ -937,7 +952,12 @@ pub fn config_network_get(
     let accept_str = "application/json";
     local_var_req_builder = local_var_req_builder.set("accept", accept_str);
 
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -949,7 +969,7 @@ pub fn config_network_get(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_entity: crate::models::NetworkConfig =
             serde_json::from_slice(&local_var_content).map_err(Error::from)?;
         let local_var_result = ResponseContent {
@@ -994,7 +1014,12 @@ pub fn config_network_put(
     };
 
     local_var_req_builder = local_var_req_builder.set("content-type", "application/json");
-    let local_var_resp = local_var_req_builder.send_json(network_config)?;
+    let local_var_result = local_var_req_builder.send_json(network_config);
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -1006,7 +1031,7 @@ pub fn config_network_put(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_result = ResponseContent {
             status: local_var_status,
             content: local_var_content_clone,
@@ -1049,7 +1074,12 @@ pub fn config_time_get(
     let accept_str = "application/json";
     local_var_req_builder = local_var_req_builder.set("accept", accept_str);
 
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -1061,7 +1091,7 @@ pub fn config_time_get(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_entity: crate::models::TimeConfig =
             serde_json::from_slice(&local_var_content).map_err(Error::from)?;
         let local_var_result = ResponseContent {
@@ -1106,7 +1136,12 @@ pub fn config_time_put(
     };
 
     local_var_req_builder = local_var_req_builder.set("content-type", "application/json");
-    let local_var_resp = local_var_req_builder.send_json(time_config)?;
+    let local_var_result = local_var_req_builder.send_json(time_config);
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -1118,7 +1153,7 @@ pub fn config_time_put(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_result = ResponseContent {
             status: local_var_status,
             content: local_var_content_clone,
@@ -1161,7 +1196,12 @@ pub fn config_tls_cert_pem_get(
     let accept_str = "application/x-pem-file";
     local_var_req_builder = local_var_req_builder.set("accept", accept_str);
 
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -1173,7 +1213,7 @@ pub fn config_tls_cert_pem_get(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_entity = String::from_utf8(local_var_content)?;
         let local_var_result = ResponseContent {
             status: local_var_status,
@@ -1218,7 +1258,12 @@ pub fn config_tls_cert_pem_put(
     };
 
     local_var_req_builder = local_var_req_builder.set("content-type", "application/x-pem-file");
-    let local_var_resp = local_var_req_builder.send_string(body)?;
+    let local_var_result = local_var_req_builder.send_string(body);
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -1230,7 +1275,7 @@ pub fn config_tls_cert_pem_put(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_result = ResponseContent {
             status: local_var_status,
             content: local_var_content_clone,
@@ -1276,7 +1321,12 @@ pub fn config_tls_csr_pem_post(
     local_var_req_builder = local_var_req_builder.set("accept", accept_str);
 
     local_var_req_builder = local_var_req_builder.set("content-type", "application/json");
-    let local_var_resp = local_var_req_builder.send_json(distinguished_name)?;
+    let local_var_result = local_var_req_builder.send_json(distinguished_name);
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -1288,7 +1338,7 @@ pub fn config_tls_csr_pem_post(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_entity = String::from_utf8(local_var_content)?;
         let local_var_result = ResponseContent {
             status: local_var_status,
@@ -1333,7 +1383,12 @@ pub fn config_tls_generate_post(
     };
 
     local_var_req_builder = local_var_req_builder.set("content-type", "application/json");
-    let local_var_resp = local_var_req_builder.send_json(tls_key_generate_request_data)?;
+    let local_var_result = local_var_req_builder.send_json(tls_key_generate_request_data);
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -1345,7 +1400,7 @@ pub fn config_tls_generate_post(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_result = ResponseContent {
             status: local_var_status,
             content: local_var_content_clone,
@@ -1392,7 +1447,12 @@ pub fn config_tls_public_pem_get(
     let accept_str = "application/x-pem-file";
     local_var_req_builder = local_var_req_builder.set("accept", accept_str);
 
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -1404,7 +1464,7 @@ pub fn config_tls_public_pem_get(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_entity = String::from_utf8(local_var_content)?;
         let local_var_result = ResponseContent {
             status: local_var_status,
@@ -1453,7 +1513,12 @@ pub fn config_unattended_boot_get(
     let accept_str = "application/json";
     local_var_req_builder = local_var_req_builder.set("accept", accept_str);
 
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -1465,7 +1530,7 @@ pub fn config_unattended_boot_get(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_entity: crate::models::UnattendedBootConfig =
             serde_json::from_slice(&local_var_content).map_err(Error::from)?;
         let local_var_result = ResponseContent {
@@ -1514,7 +1579,12 @@ pub fn config_unattended_boot_put(
     };
 
     local_var_req_builder = local_var_req_builder.set("content-type", "application/json");
-    let local_var_resp = local_var_req_builder.send_json(unattended_boot_config)?;
+    let local_var_result = local_var_req_builder.send_json(unattended_boot_config);
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -1526,7 +1596,7 @@ pub fn config_unattended_boot_put(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_result = ResponseContent {
             status: local_var_status,
             content: local_var_content_clone,
@@ -1573,7 +1643,12 @@ pub fn config_unlock_passphrase_put(
     };
 
     local_var_req_builder = local_var_req_builder.set("content-type", "application/json");
-    let local_var_resp = local_var_req_builder.send_json(unlock_passphrase_config)?;
+    let local_var_result = local_var_req_builder.send_json(unlock_passphrase_config);
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -1585,7 +1660,7 @@ pub fn config_unlock_passphrase_put(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_result = ResponseContent {
             status: local_var_status,
             content: local_var_content_clone,
@@ -1622,7 +1697,12 @@ pub fn health_alive_get(
         local_var_req_builder = local_var_req_builder.set("user-agent", local_var_user_agent);
     }
 
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -1634,7 +1714,7 @@ pub fn health_alive_get(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_result = ResponseContent {
             status: local_var_status,
             content: local_var_content_clone,
@@ -1670,7 +1750,12 @@ pub fn health_ready_get(
         local_var_req_builder = local_var_req_builder.set("user-agent", local_var_user_agent);
     }
 
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -1682,7 +1767,7 @@ pub fn health_ready_get(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_result = ResponseContent {
             status: local_var_status,
             content: local_var_content_clone,
@@ -1720,7 +1805,12 @@ pub fn health_state_get(
     let accept_str = "application/json";
     local_var_req_builder = local_var_req_builder.set("accept", accept_str);
 
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -1732,7 +1822,7 @@ pub fn health_state_get(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_entity: crate::models::HealthStateData =
             serde_json::from_slice(&local_var_content).map_err(Error::from)?;
         let local_var_result = ResponseContent {
@@ -1772,7 +1862,12 @@ pub fn info_get(
     let accept_str = "application/json";
     local_var_req_builder = local_var_req_builder.set("accept", accept_str);
 
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -1784,7 +1879,7 @@ pub fn info_get(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_entity: crate::models::InfoData =
             serde_json::from_slice(&local_var_content).map_err(Error::from)?;
         let local_var_result = ResponseContent {
@@ -1831,7 +1926,12 @@ pub fn keys_generate_post(
     local_var_req_builder = local_var_req_builder.set("accept", accept_str);
 
     local_var_req_builder = local_var_req_builder.set("content-type", "application/json");
-    let local_var_resp = local_var_req_builder.send_json(key_generate_request_data)?;
+    let local_var_result = local_var_req_builder.send_json(key_generate_request_data);
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -1843,7 +1943,7 @@ pub fn keys_generate_post(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_entity: crate::models::CreateResourceId =
             serde_json::from_slice(&local_var_content).map_err(Error::from)?;
         let local_var_result = ResponseContent {
@@ -1893,7 +1993,12 @@ pub fn keys_get(
     let accept_str = "application/json";
     local_var_req_builder = local_var_req_builder.set("accept", accept_str);
 
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -1905,7 +2010,7 @@ pub fn keys_get(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_entity: Vec<crate::models::KeyItem> =
             serde_json::from_slice(&local_var_content).map_err(Error::from)?;
         let local_var_result = ResponseContent {
@@ -1953,7 +2058,12 @@ pub fn keys_key_id_cert_delete(
         local_var_req_builder = local_var_req_builder.set("authorization", &value);
     };
 
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -1965,7 +2075,7 @@ pub fn keys_key_id_cert_delete(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_result = ResponseContent {
             status: local_var_status,
             content: local_var_content_clone,
@@ -2014,7 +2124,12 @@ pub fn keys_key_id_cert_get(
     let accept_str = "application/octet-stream";
     local_var_req_builder = local_var_req_builder.set("accept", accept_str);
 
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -2026,7 +2141,7 @@ pub fn keys_key_id_cert_get(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_entity = local_var_content.clone();
         let local_var_result = ResponseContent {
             status: local_var_status,
@@ -2076,7 +2191,12 @@ pub fn keys_key_id_cert_put(
 
     local_var_req_builder = local_var_req_builder.set("content-type", "application/octet-stream");
     let body = std::io::Cursor::new(body);
-    let local_var_resp = local_var_req_builder.send(body)?;
+    let local_var_result = local_var_req_builder.send(body);
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -2088,7 +2208,7 @@ pub fn keys_key_id_cert_put(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_result = ResponseContent {
             status: local_var_status,
             content: local_var_content_clone,
@@ -2138,7 +2258,12 @@ pub fn keys_key_id_csr_pem_post(
     local_var_req_builder = local_var_req_builder.set("accept", accept_str);
 
     local_var_req_builder = local_var_req_builder.set("content-type", "application/json");
-    let local_var_resp = local_var_req_builder.send_json(distinguished_name)?;
+    let local_var_result = local_var_req_builder.send_json(distinguished_name);
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -2150,7 +2275,7 @@ pub fn keys_key_id_csr_pem_post(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_entity = String::from_utf8(local_var_content)?;
         let local_var_result = ResponseContent {
             status: local_var_status,
@@ -2202,7 +2327,12 @@ pub fn keys_key_id_decrypt_post(
     local_var_req_builder = local_var_req_builder.set("accept", accept_str);
 
     local_var_req_builder = local_var_req_builder.set("content-type", "application/json");
-    let local_var_resp = local_var_req_builder.send_json(decrypt_request_data)?;
+    let local_var_result = local_var_req_builder.send_json(decrypt_request_data);
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -2214,7 +2344,7 @@ pub fn keys_key_id_decrypt_post(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_entity: crate::models::DecryptData =
             serde_json::from_slice(&local_var_content).map_err(Error::from)?;
         let local_var_result = ResponseContent {
@@ -2263,7 +2393,12 @@ pub fn keys_key_id_delete(
         local_var_req_builder = local_var_req_builder.set("authorization", &value);
     };
 
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -2275,7 +2410,7 @@ pub fn keys_key_id_delete(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_result = ResponseContent {
             status: local_var_status,
             content: local_var_content_clone,
@@ -2325,7 +2460,12 @@ pub fn keys_key_id_encrypt_post(
     local_var_req_builder = local_var_req_builder.set("accept", accept_str);
 
     local_var_req_builder = local_var_req_builder.set("content-type", "application/json");
-    let local_var_resp = local_var_req_builder.send_json(encrypt_request_data)?;
+    let local_var_result = local_var_req_builder.send_json(encrypt_request_data);
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -2337,7 +2477,7 @@ pub fn keys_key_id_encrypt_post(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_entity: crate::models::EncryptData =
             serde_json::from_slice(&local_var_content).map_err(Error::from)?;
         let local_var_result = ResponseContent {
@@ -2388,7 +2528,12 @@ pub fn keys_key_id_get(
     let accept_str = "application/json";
     local_var_req_builder = local_var_req_builder.set("accept", accept_str);
 
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -2400,7 +2545,7 @@ pub fn keys_key_id_get(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_entity: crate::models::PublicKey =
             serde_json::from_slice(&local_var_content).map_err(Error::from)?;
         let local_var_result = ResponseContent {
@@ -2450,7 +2595,12 @@ pub fn keys_key_id_public_pem_get(
     let accept_str = "application/x-pem-file";
     local_var_req_builder = local_var_req_builder.set("accept", accept_str);
 
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -2462,7 +2612,7 @@ pub fn keys_key_id_public_pem_get(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_entity = String::from_utf8(local_var_content)?;
         let local_var_result = ResponseContent {
             status: local_var_status,
@@ -2514,11 +2664,16 @@ pub fn keys_key_id_put(
     let body_json = body.is_json();
     local_var_req_builder = local_var_req_builder.set("content-type", body.content_type());
 
-    let local_var_resp = if body_json {
-        local_var_req_builder.send_json(body)?
+    let local_var_result = if body_json {
+        local_var_req_builder.send_json(body)
     } else {
-        local_var_req_builder.send_string(body.get_string().as_str())?
+        local_var_req_builder.send_string(body.get_string().as_str())
     };
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -2530,7 +2685,7 @@ pub fn keys_key_id_put(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_result = ResponseContent {
             status: local_var_status,
             content: local_var_content_clone,
@@ -2578,7 +2733,12 @@ pub fn keys_key_id_restrictions_tags_tag_delete(
         local_var_req_builder = local_var_req_builder.set("authorization", &value);
     };
 
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -2590,7 +2750,7 @@ pub fn keys_key_id_restrictions_tags_tag_delete(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_result = ResponseContent {
             status: local_var_status,
             content: local_var_content_clone,
@@ -2639,7 +2799,12 @@ pub fn keys_key_id_restrictions_tags_tag_put(
         local_var_req_builder = local_var_req_builder.set("authorization", &value);
     };
 
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -2651,7 +2816,7 @@ pub fn keys_key_id_restrictions_tags_tag_put(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_result = ResponseContent {
             status: local_var_status,
             content: local_var_content_clone,
@@ -2702,7 +2867,12 @@ pub fn keys_key_id_sign_post(
     local_var_req_builder = local_var_req_builder.set("accept", accept_str);
 
     local_var_req_builder = local_var_req_builder.set("content-type", "application/json");
-    let local_var_resp = local_var_req_builder.send_json(sign_request_data)?;
+    let local_var_result = local_var_req_builder.send_json(sign_request_data);
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -2714,7 +2884,7 @@ pub fn keys_key_id_sign_post(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_entity: crate::models::SignData =
             serde_json::from_slice(&local_var_content).map_err(Error::from)?;
         let local_var_result = ResponseContent {
@@ -2763,11 +2933,16 @@ pub fn keys_post(
     let body_json = body.is_json();
     local_var_req_builder = local_var_req_builder.set("content-type", body.content_type());
 
-    let local_var_resp = if body_json {
-        local_var_req_builder.send_json(body)?
+    let local_var_result = if body_json {
+        local_var_req_builder.send_json(body)
     } else {
-        local_var_req_builder.send_string(body.get_string().as_str())?
+        local_var_req_builder.send_string(body.get_string().as_str())
     };
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -2779,7 +2954,7 @@ pub fn keys_post(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_entity: crate::models::CreateResourceId =
             serde_json::from_slice(&local_var_content).map_err(Error::from)?;
         let local_var_result = ResponseContent {
@@ -2822,7 +2997,12 @@ pub fn lock_post(
         local_var_req_builder = local_var_req_builder.set("authorization", &value);
     };
 
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -2834,7 +3014,7 @@ pub fn lock_post(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_result = ResponseContent {
             status: local_var_status,
             content: local_var_content_clone,
@@ -2877,7 +3057,12 @@ pub fn metrics_get(
     let accept_str = "application/json";
     local_var_req_builder = local_var_req_builder.set("accept", accept_str);
 
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -2889,7 +3074,7 @@ pub fn metrics_get(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_entity: serde_json::Value =
             serde_json::from_slice(&local_var_content).map_err(Error::from)?;
         let local_var_result = ResponseContent {
@@ -2929,7 +3114,12 @@ pub fn provision_post(
     }
 
     local_var_req_builder = local_var_req_builder.set("content-type", "application/json");
-    let local_var_resp = local_var_req_builder.send_json(provision_request_data)?;
+    let local_var_result = local_var_req_builder.send_json(provision_request_data);
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -2941,7 +3131,7 @@ pub fn provision_post(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_result = ResponseContent {
             status: local_var_status,
             content: local_var_content_clone,
@@ -2986,7 +3176,12 @@ pub fn random_post(
     local_var_req_builder = local_var_req_builder.set("accept", accept_str);
 
     local_var_req_builder = local_var_req_builder.set("content-type", "application/json");
-    let local_var_resp = local_var_req_builder.send_json(random_request_data)?;
+    let local_var_result = local_var_req_builder.send_json(random_request_data);
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -2998,7 +3193,7 @@ pub fn random_post(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_entity: crate::models::RandomData =
             serde_json::from_slice(&local_var_content).map_err(Error::from)?;
         let local_var_result = ResponseContent {
@@ -3043,7 +3238,12 @@ pub fn system_backup_post(
     let accept_str = "application/octet-stream";
     local_var_req_builder = local_var_req_builder.set("accept", accept_str);
 
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -3055,7 +3255,7 @@ pub fn system_backup_post(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_entity = local_var_content.clone();
         let local_var_result = ResponseContent {
             status: local_var_status,
@@ -3097,7 +3297,12 @@ pub fn system_cancel_update_post(
         local_var_req_builder = local_var_req_builder.set("authorization", &value);
     };
 
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -3109,7 +3314,7 @@ pub fn system_cancel_update_post(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_result = ResponseContent {
             status: local_var_status,
             content: local_var_content_clone,
@@ -3151,7 +3356,12 @@ pub fn system_commit_update_post(
         local_var_req_builder = local_var_req_builder.set("authorization", &value);
     };
 
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -3163,7 +3373,7 @@ pub fn system_commit_update_post(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_result = ResponseContent {
             status: local_var_status,
             content: local_var_content_clone,
@@ -3205,7 +3415,12 @@ pub fn system_factory_reset_post(
         local_var_req_builder = local_var_req_builder.set("authorization", &value);
     };
 
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -3217,7 +3432,7 @@ pub fn system_factory_reset_post(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_result = ResponseContent {
             status: local_var_status,
             content: local_var_content_clone,
@@ -3261,7 +3476,12 @@ pub fn system_info_get(
     let accept_str = "application/json";
     local_var_req_builder = local_var_req_builder.set("accept", accept_str);
 
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -3273,7 +3493,7 @@ pub fn system_info_get(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_entity: crate::models::SystemInfo =
             serde_json::from_slice(&local_var_content).map_err(Error::from)?;
         let local_var_result = ResponseContent {
@@ -3316,7 +3536,12 @@ pub fn system_reboot_post(
         local_var_req_builder = local_var_req_builder.set("authorization", &value);
     };
 
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -3328,7 +3553,7 @@ pub fn system_reboot_post(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_result = ResponseContent {
             status: local_var_status,
             content: local_var_content_clone,
@@ -3368,7 +3593,12 @@ pub fn system_restore_post(
 
     local_var_req_builder = local_var_req_builder.set("content-type", "multipart/form-data");
 
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -3380,7 +3610,7 @@ pub fn system_restore_post(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_result = ResponseContent {
             status: local_var_status,
             content: local_var_content_clone,
@@ -3421,7 +3651,12 @@ pub fn system_shutdown_post(
         local_var_req_builder = local_var_req_builder.set("authorization", &value);
     };
 
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -3433,7 +3668,7 @@ pub fn system_shutdown_post(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_result = ResponseContent {
             status: local_var_status,
             content: local_var_content_clone,
@@ -3479,7 +3714,12 @@ pub fn system_update_post(
 
     local_var_req_builder = local_var_req_builder.set("content-type", "application/octet-stream");
     let body = std::io::Cursor::new(body);
-    let local_var_resp = local_var_req_builder.send(body)?;
+    let local_var_result = local_var_req_builder.send(body);
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -3491,7 +3731,7 @@ pub fn system_update_post(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_entity: crate::models::SystemUpdateData =
             serde_json::from_slice(&local_var_content).map_err(Error::from)?;
         let local_var_result = ResponseContent {
@@ -3531,7 +3771,12 @@ pub fn unlock_post(
     }
 
     local_var_req_builder = local_var_req_builder.set("content-type", "application/json");
-    let local_var_resp = local_var_req_builder.send_json(unlock_request_data)?;
+    let local_var_result = local_var_req_builder.send_json(unlock_request_data);
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -3543,7 +3788,7 @@ pub fn unlock_post(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_result = ResponseContent {
             status: local_var_status,
             content: local_var_content_clone,
@@ -3586,7 +3831,12 @@ pub fn users_get(
     let accept_str = "application/json";
     local_var_req_builder = local_var_req_builder.set("accept", accept_str);
 
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -3598,7 +3848,7 @@ pub fn users_get(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_entity: Vec<crate::models::UserItem> =
             serde_json::from_slice(&local_var_content).map_err(Error::from)?;
         let local_var_result = ResponseContent {
@@ -3645,7 +3895,12 @@ pub fn users_post(
     local_var_req_builder = local_var_req_builder.set("accept", accept_str);
 
     local_var_req_builder = local_var_req_builder.set("content-type", "application/json");
-    let local_var_resp = local_var_req_builder.send_json(user_post_data)?;
+    let local_var_result = local_var_req_builder.send_json(user_post_data);
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -3657,7 +3912,7 @@ pub fn users_post(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_entity: crate::models::CreateResourceId =
             serde_json::from_slice(&local_var_content).map_err(Error::from)?;
         let local_var_result = ResponseContent {
@@ -3705,7 +3960,12 @@ pub fn users_user_id_delete(
         local_var_req_builder = local_var_req_builder.set("authorization", &value);
     };
 
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -3717,7 +3977,7 @@ pub fn users_user_id_delete(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_result = ResponseContent {
             status: local_var_status,
             content: local_var_content_clone,
@@ -3765,7 +4025,12 @@ pub fn users_user_id_get(
     let accept_str = "application/json";
     local_var_req_builder = local_var_req_builder.set("accept", accept_str);
 
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -3777,7 +4042,7 @@ pub fn users_user_id_get(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_entity: crate::models::UserData =
             serde_json::from_slice(&local_var_content).map_err(Error::from)?;
         let local_var_result = ResponseContent {
@@ -3827,7 +4092,12 @@ pub fn users_user_id_passphrase_post(
     };
 
     local_var_req_builder = local_var_req_builder.set("content-type", "application/json");
-    let local_var_resp = local_var_req_builder.send_json(user_passphrase_post_data)?;
+    let local_var_result = local_var_req_builder.send_json(user_passphrase_post_data);
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -3839,7 +4109,7 @@ pub fn users_user_id_passphrase_post(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_result = ResponseContent {
             status: local_var_status,
             content: local_var_content_clone,
@@ -3888,7 +4158,12 @@ pub fn users_user_id_put(
     };
 
     local_var_req_builder = local_var_req_builder.set("content-type", "application/json");
-    let local_var_resp = local_var_req_builder.send_json(user_post_data)?;
+    let local_var_result = local_var_req_builder.send_json(user_post_data);
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -3900,7 +4175,7 @@ pub fn users_user_id_put(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_result = ResponseContent {
             status: local_var_status,
             content: local_var_content_clone,
@@ -3948,7 +4223,12 @@ pub fn users_user_id_tags_get(
     let accept_str = "application/json";
     local_var_req_builder = local_var_req_builder.set("accept", accept_str);
 
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -3960,7 +4240,7 @@ pub fn users_user_id_tags_get(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_entity: Vec<String> =
             serde_json::from_slice(&local_var_content).map_err(Error::from)?;
         let local_var_result = ResponseContent {
@@ -4010,7 +4290,12 @@ pub fn users_user_id_tags_tag_delete(
         local_var_req_builder = local_var_req_builder.set("authorization", &value);
     };
 
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -4022,7 +4307,7 @@ pub fn users_user_id_tags_tag_delete(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_result = ResponseContent {
             status: local_var_status,
             content: local_var_content_clone,
@@ -4071,7 +4356,12 @@ pub fn users_user_id_tags_tag_put(
         local_var_req_builder = local_var_req_builder.set("authorization", &value);
     };
 
-    let local_var_resp = local_var_req_builder.call()?;
+    let local_var_result = local_var_req_builder.call();
+
+    let local_var_resp = local_var_result.or_else(|err| match err {
+        ureq::Error::Status(_status, resp) => Ok(resp),
+        _ => Err(err),
+    })?;
 
     let local_var_headers = super::get_header_map(&local_var_resp);
 
@@ -4083,7 +4373,7 @@ pub fn users_user_id_tags_tag_put(
 
     let local_var_content_clone = local_var_content.clone();
 
-    if !local_var_status >= 400 {
+    if local_var_status < 400 {
         let local_var_result = ResponseContent {
             status: local_var_status,
             content: local_var_content_clone,

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,12 +1,33 @@
 mod utils;
 
-use nethsm_sdk_rs::apis::default_api;
+use nethsm_sdk_rs::apis::{default_api, Error};
 
 #[tokio::test]
 async fn test_health_state() {
     utils::with_container(|config| {
         let result = default_api::health_state_get(&config);
         assert!(result.is_ok(), "{result:?}");
+    })
+    .await
+}
+
+#[tokio::test]
+async fn test_error() {
+    utils::with_container(|config| {
+        let err = default_api::keys_get(&config, None).err().unwrap();
+        match err {
+            Error::ResponseError(content) => {
+                assert_eq!(content.status, 412);
+                let err = String::from_utf8_lossy(&content.content);
+                assert!(
+                    err.contains("Service not available"),
+                    "unexpected error message: {err}"
+                );
+            }
+            _ => {
+                panic!("Unexpected error variant: {err:?}");
+            }
+        }
     })
     .await
 }


### PR DESCRIPTION
Due to a bug in the error handling code, we previously returned Error::Transport for API errors.  With this patch, we correctly return Error::ResponseError.  This also means that the error message from the NetHSM can be accessed using the content field of the ResponseContent. Unfortunately, it is not yet deserialized as it is not described in the API spec.

Fixes: https://github.com/Nitrokey/nethsm-sdk-rs/issues/21