### PR TITLE
feat: Implement `Display` for enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
--
+### Features
+
+- Implement `Display` for enums (@wiktor-k, [#33](https://github.com/Nitrokey/nethsm-sdk-rs/pull/33))
 
 [All Changes](https://github.com/Nitrokey/nethsm-sdk-rs/compare/v1.1.0...HEAD)
 

--- a/generator/src/main/resources/crust/model.mustache
+++ b/generator/src/main/resources/crust/model.mustache
@@ -17,15 +17,15 @@ pub enum {{{classname}}} {
 {{/enumVars}}{{/allowableValues}}
 }
 
-impl ToString for {{{classname}}} {
-    fn to_string(&self) -> String {
-        match self {
+impl std::fmt::Display for {{{classname}}} {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", match self {
             {{#allowableValues}}
             {{#enumVars}}
-            Self::{{{name}}} => String::from("{{{value}}}"),
+            Self::{{{name}}} => "{{{value}}}",
             {{/enumVars}}
             {{/allowableValues}}
-        }
+        })
     }
 }
 

--- a/src/models/decrypt_mode.rs
+++ b/src/models/decrypt_mode.rs
@@ -31,19 +31,23 @@ pub enum DecryptMode {
     AesCbc,
 }
 
-impl ToString for DecryptMode {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Raw => String::from("RAW"),
-            Self::Pkcs1 => String::from("PKCS1"),
-            Self::OaepMd5 => String::from("OAEP_MD5"),
-            Self::OaepSha1 => String::from("OAEP_SHA1"),
-            Self::OaepSha224 => String::from("OAEP_SHA224"),
-            Self::OaepSha256 => String::from("OAEP_SHA256"),
-            Self::OaepSha384 => String::from("OAEP_SHA384"),
-            Self::OaepSha512 => String::from("OAEP_SHA512"),
-            Self::AesCbc => String::from("AES_CBC"),
-        }
+impl std::fmt::Display for DecryptMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Raw => "RAW",
+                Self::Pkcs1 => "PKCS1",
+                Self::OaepMd5 => "OAEP_MD5",
+                Self::OaepSha1 => "OAEP_SHA1",
+                Self::OaepSha224 => "OAEP_SHA224",
+                Self::OaepSha256 => "OAEP_SHA256",
+                Self::OaepSha384 => "OAEP_SHA384",
+                Self::OaepSha512 => "OAEP_SHA512",
+                Self::AesCbc => "AES_CBC",
+            }
+        )
     }
 }
 

--- a/src/models/encrypt_mode.rs
+++ b/src/models/encrypt_mode.rs
@@ -15,11 +15,15 @@ pub enum EncryptMode {
     AesCbc,
 }
 
-impl ToString for EncryptMode {
-    fn to_string(&self) -> String {
-        match self {
-            Self::AesCbc => String::from("AES_CBC"),
-        }
+impl std::fmt::Display for EncryptMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::AesCbc => "AES_CBC",
+            }
+        )
     }
 }
 

--- a/src/models/key_mechanism.rs
+++ b/src/models/key_mechanism.rs
@@ -51,29 +51,33 @@ pub enum KeyMechanism {
     AesDecryptionCbc,
 }
 
-impl ToString for KeyMechanism {
-    fn to_string(&self) -> String {
-        match self {
-            Self::RsaDecryptionRaw => String::from("RSA_Decryption_RAW"),
-            Self::RsaDecryptionPkcs1 => String::from("RSA_Decryption_PKCS1"),
-            Self::RsaDecryptionOaepMd5 => String::from("RSA_Decryption_OAEP_MD5"),
-            Self::RsaDecryptionOaepSha1 => String::from("RSA_Decryption_OAEP_SHA1"),
-            Self::RsaDecryptionOaepSha224 => String::from("RSA_Decryption_OAEP_SHA224"),
-            Self::RsaDecryptionOaepSha256 => String::from("RSA_Decryption_OAEP_SHA256"),
-            Self::RsaDecryptionOaepSha384 => String::from("RSA_Decryption_OAEP_SHA384"),
-            Self::RsaDecryptionOaepSha512 => String::from("RSA_Decryption_OAEP_SHA512"),
-            Self::RsaSignaturePkcs1 => String::from("RSA_Signature_PKCS1"),
-            Self::RsaSignaturePssMd5 => String::from("RSA_Signature_PSS_MD5"),
-            Self::RsaSignaturePssSha1 => String::from("RSA_Signature_PSS_SHA1"),
-            Self::RsaSignaturePssSha224 => String::from("RSA_Signature_PSS_SHA224"),
-            Self::RsaSignaturePssSha256 => String::from("RSA_Signature_PSS_SHA256"),
-            Self::RsaSignaturePssSha384 => String::from("RSA_Signature_PSS_SHA384"),
-            Self::RsaSignaturePssSha512 => String::from("RSA_Signature_PSS_SHA512"),
-            Self::EdDsaSignature => String::from("EdDSA_Signature"),
-            Self::EcdsaSignature => String::from("ECDSA_Signature"),
-            Self::AesEncryptionCbc => String::from("AES_Encryption_CBC"),
-            Self::AesDecryptionCbc => String::from("AES_Decryption_CBC"),
-        }
+impl std::fmt::Display for KeyMechanism {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::RsaDecryptionRaw => "RSA_Decryption_RAW",
+                Self::RsaDecryptionPkcs1 => "RSA_Decryption_PKCS1",
+                Self::RsaDecryptionOaepMd5 => "RSA_Decryption_OAEP_MD5",
+                Self::RsaDecryptionOaepSha1 => "RSA_Decryption_OAEP_SHA1",
+                Self::RsaDecryptionOaepSha224 => "RSA_Decryption_OAEP_SHA224",
+                Self::RsaDecryptionOaepSha256 => "RSA_Decryption_OAEP_SHA256",
+                Self::RsaDecryptionOaepSha384 => "RSA_Decryption_OAEP_SHA384",
+                Self::RsaDecryptionOaepSha512 => "RSA_Decryption_OAEP_SHA512",
+                Self::RsaSignaturePkcs1 => "RSA_Signature_PKCS1",
+                Self::RsaSignaturePssMd5 => "RSA_Signature_PSS_MD5",
+                Self::RsaSignaturePssSha1 => "RSA_Signature_PSS_SHA1",
+                Self::RsaSignaturePssSha224 => "RSA_Signature_PSS_SHA224",
+                Self::RsaSignaturePssSha256 => "RSA_Signature_PSS_SHA256",
+                Self::RsaSignaturePssSha384 => "RSA_Signature_PSS_SHA384",
+                Self::RsaSignaturePssSha512 => "RSA_Signature_PSS_SHA512",
+                Self::EdDsaSignature => "EdDSA_Signature",
+                Self::EcdsaSignature => "ECDSA_Signature",
+                Self::AesEncryptionCbc => "AES_Encryption_CBC",
+                Self::AesDecryptionCbc => "AES_Decryption_CBC",
+            }
+        )
     }
 }
 

--- a/src/models/key_type.rs
+++ b/src/models/key_type.rs
@@ -27,17 +27,21 @@ pub enum KeyType {
     Generic,
 }
 
-impl ToString for KeyType {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Rsa => String::from("RSA"),
-            Self::Curve25519 => String::from("Curve25519"),
-            Self::EcP224 => String::from("EC_P224"),
-            Self::EcP256 => String::from("EC_P256"),
-            Self::EcP384 => String::from("EC_P384"),
-            Self::EcP521 => String::from("EC_P521"),
-            Self::Generic => String::from("Generic"),
-        }
+impl std::fmt::Display for KeyType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Rsa => "RSA",
+                Self::Curve25519 => "Curve25519",
+                Self::EcP224 => "EC_P224",
+                Self::EcP256 => "EC_P256",
+                Self::EcP384 => "EC_P384",
+                Self::EcP521 => "EC_P521",
+                Self::Generic => "Generic",
+            }
+        )
     }
 }
 

--- a/src/models/log_level.rs
+++ b/src/models/log_level.rs
@@ -21,14 +21,18 @@ pub enum LogLevel {
     Error,
 }
 
-impl ToString for LogLevel {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Debug => String::from("debug"),
-            Self::Info => String::from("info"),
-            Self::Warning => String::from("warning"),
-            Self::Error => String::from("error"),
-        }
+impl std::fmt::Display for LogLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Debug => "debug",
+                Self::Info => "info",
+                Self::Warning => "warning",
+                Self::Error => "error",
+            }
+        )
     }
 }
 

--- a/src/models/sign_mode.rs
+++ b/src/models/sign_mode.rs
@@ -31,19 +31,23 @@ pub enum SignMode {
     Ecdsa,
 }
 
-impl ToString for SignMode {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Pkcs1 => String::from("PKCS1"),
-            Self::PssMd5 => String::from("PSS_MD5"),
-            Self::PssSha1 => String::from("PSS_SHA1"),
-            Self::PssSha224 => String::from("PSS_SHA224"),
-            Self::PssSha256 => String::from("PSS_SHA256"),
-            Self::PssSha384 => String::from("PSS_SHA384"),
-            Self::PssSha512 => String::from("PSS_SHA512"),
-            Self::EdDsa => String::from("EdDSA"),
-            Self::Ecdsa => String::from("ECDSA"),
-        }
+impl std::fmt::Display for SignMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Pkcs1 => "PKCS1",
+                Self::PssMd5 => "PSS_MD5",
+                Self::PssSha1 => "PSS_SHA1",
+                Self::PssSha224 => "PSS_SHA224",
+                Self::PssSha256 => "PSS_SHA256",
+                Self::PssSha384 => "PSS_SHA384",
+                Self::PssSha512 => "PSS_SHA512",
+                Self::EdDsa => "EdDSA",
+                Self::Ecdsa => "ECDSA",
+            }
+        )
     }
 }
 

--- a/src/models/switch.rs
+++ b/src/models/switch.rs
@@ -17,12 +17,16 @@ pub enum Switch {
     Off,
 }
 
-impl ToString for Switch {
-    fn to_string(&self) -> String {
-        match self {
-            Self::On => String::from("on"),
-            Self::Off => String::from("off"),
-        }
+impl std::fmt::Display for Switch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::On => "on",
+                Self::Off => "off",
+            }
+        )
     }
 }
 

--- a/src/models/system_state.rs
+++ b/src/models/system_state.rs
@@ -19,13 +19,17 @@ pub enum SystemState {
     Operational,
 }
 
-impl ToString for SystemState {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Unprovisioned => String::from("Unprovisioned"),
-            Self::Locked => String::from("Locked"),
-            Self::Operational => String::from("Operational"),
-        }
+impl std::fmt::Display for SystemState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Unprovisioned => "Unprovisioned",
+                Self::Locked => "Locked",
+                Self::Operational => "Operational",
+            }
+        )
     }
 }
 

--- a/src/models/tls_key_type.rs
+++ b/src/models/tls_key_type.rs
@@ -25,16 +25,20 @@ pub enum TlsKeyType {
     EcP521,
 }
 
-impl ToString for TlsKeyType {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Rsa => String::from("RSA"),
-            Self::Curve25519 => String::from("Curve25519"),
-            Self::EcP224 => String::from("EC_P224"),
-            Self::EcP256 => String::from("EC_P256"),
-            Self::EcP384 => String::from("EC_P384"),
-            Self::EcP521 => String::from("EC_P521"),
-        }
+impl std::fmt::Display for TlsKeyType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Rsa => "RSA",
+                Self::Curve25519 => "Curve25519",
+                Self::EcP224 => "EC_P224",
+                Self::EcP256 => "EC_P256",
+                Self::EcP384 => "EC_P384",
+                Self::EcP521 => "EC_P521",
+            }
+        )
     }
 }
 

--- a/src/models/user_role.rs
+++ b/src/models/user_role.rs
@@ -21,14 +21,18 @@ pub enum UserRole {
     Backup,
 }
 
-impl ToString for UserRole {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Administrator => String::from("Administrator"),
-            Self::Operator => String::from("Operator"),
-            Self::Metrics => String::from("Metrics"),
-            Self::Backup => String::from("Backup"),
-        }
+impl std::fmt::Display for UserRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Administrator => "Administrator",
+                Self::Operator => "Operator",
+                Self::Metrics => "Metrics",
+                Self::Backup => "Backup",
+            }
+        )
     }
 }
 


### PR DESCRIPTION
I've updated the template and run `update_openapi.sh`.

It should make it easier for Rust devs a bit. Please test as I'm not *that* familiar with openapi-generator (it does compiles and renders nice docs though).

(btw, I've also locally used `podman` instead of `docker` which has a nice effect of not having to require a docker daemon)

Fixes: https://github.com/Nitrokey/nethsm-sdk-rs/issues/32