### PR TITLE
Update GitHub Actions checkout

### DIFF
--- a/.github/workflows/cd-test.yml
+++ b/.github/workflows/cd-test.yml
@@ -11,5 +11,5 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-publish-check') }}
     steps:
-    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+    - uses: actions/checkout@v6
     - run: cargo publish --dry-run

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+    - uses: actions/checkout@v6
     - uses: rust-lang/crates-io-auth-action@e919bc7605cde86df457cf5b93c5e103838bd879  # v1.0.1
       id: auth
     - run: cargo publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     name: Check library
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v6
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
@@ -23,7 +23,7 @@ jobs:
     name: Run tests
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v6
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
@@ -36,7 +36,7 @@ jobs:
     name: Run rustfmt
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v6
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
@@ -50,7 +50,7 @@ jobs:
     name: Run clippy
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v6
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal


### PR DESCRIPTION
This PR update the following action used in the CI/CD pipelines.

- `actions/checkout` from `v4` to `v6`