### PR TITLE
Replace GitHub Actions actions-rs/toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
+    - uses: dtolnay/rust-toolchain@stable
     - name: Check library
       run: cargo check --all-targets
 
@@ -24,11 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
+    - uses: dtolnay/rust-toolchain@stable
     - name: Run tests
       run: cargo test
 
@@ -37,11 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@stable
       with:
-        profile: minimal
-        toolchain: stable
-        override: true
         components: "rustfmt"
     - name: Run rustfmt
       run: cargo fmt -- --check
@@ -51,11 +40,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@stable
       with:
-        profile: minimal
-        toolchain: stable
-        override: true
         components: "clippy"
     - name: Run clippy
       run: cargo clippy --all-features --all-targets


### PR DESCRIPTION
This PR replaces the following action used in the CI/CD pipelines.

- `actions-rs/toolchain@v1` with `dtolnay/rust-toolchain@stable`

The replacement is necessary as `actions-rs/toolchain` is deprecated (repository is archived). The new action is from a reputable Rust developer and is actively maintained. 